### PR TITLE
Add Banapass Reader Redirection

### DIFF
--- a/Dist/config.toml
+++ b/Dist/config.toml
@@ -13,7 +13,7 @@ redirect = true
 path = "/dev/ttyACM1"
 
 [term_spoof]
-enabled = false
+enabled = true
 
 [emu]
 jvs = true

--- a/Dist/config.toml
+++ b/Dist/config.toml
@@ -12,6 +12,9 @@ chip_id = "222"
 redirect = true
 path = "/dev/ttyACM1"
 
+[term_spoof]
+enabled = false
+
 [emu]
 jvs = true
 str400 = true

--- a/Dist/config.toml
+++ b/Dist/config.toml
@@ -8,6 +8,10 @@ enabled = true
 access_code = "111"
 chip_id = "222"
 
+[bana_redir]
+redirect = true
+path = "/dev/ttyACM1"
+
 [emu]
 jvs = true
 str400 = true

--- a/config.cpp
+++ b/config.cpp
@@ -15,6 +15,7 @@ bool useKeyboard = true;
 bool useBana = true;
 bool useLimiter = true;
 char* redirectBanaReader = NULL;
+bool termSpoof = true;
 
 char* copyCharString(char* str) {
     size_t len = strlen(str);
@@ -50,6 +51,10 @@ bool loadConfig() {
         auto banaRedirConfig = config["bana_redir"];
         if (banaRedirConfig.is_table() && banaRedirConfig["redirect"].as_boolean()->get())
             redirectBanaReader = createCharString(banaRedirConfig["path"].as_string()->get());
+
+        auto termSpoofConfig = config["term_spoof"];
+        if (termSpoofConfig.is_table())
+            termSpoof = termSpoofConfig["enabled"].as_boolean()->get();
 
         auto emuConfig = config["emu"];
         useJvs = emuConfig["jvs"].as_boolean()->get();

--- a/config.cpp
+++ b/config.cpp
@@ -48,7 +48,7 @@ bool loadConfig() {
         }
 
         auto banaRedirConfig = config["bana_redir"];
-        if (banaRedirConfig["redirect"].as_boolean()->get())
+        if (banaRedirConfig.is_table() && banaRedirConfig["redirect"].as_boolean()->get())
             redirectBanaReader = createCharString(banaRedirConfig["path"].as_string()->get());
 
         auto emuConfig = config["emu"];

--- a/config.cpp
+++ b/config.cpp
@@ -14,6 +14,7 @@ bool useTouch = true;
 bool useKeyboard = true;
 bool useBana = true;
 bool useLimiter = true;
+char* redirectBanaReader = NULL;
 
 char* copyCharString(char* str) {
     size_t len = strlen(str);
@@ -45,6 +46,10 @@ bool loadConfig() {
             accessCode = createCharString(banaConfig["access_code"].as_string()->get());
             chipID = createCharString(banaConfig["chip_id"].as_string()->get());
         }
+
+        auto banaRedirConfig = config["bana_redir"];
+        if (banaRedirConfig["redirect"].as_boolean()->get())
+            redirectBanaReader = createCharString(banaRedirConfig["path"].as_string()->get());
 
         auto emuConfig = config["emu"];
         useJvs = emuConfig["jvs"].as_boolean()->get();

--- a/config.h
+++ b/config.h
@@ -14,5 +14,6 @@ extern bool useTouch;
 extern bool useKeyboard;
 extern bool useBana;
 extern bool useLimiter;
+extern char* redirectBanaReader;
 
 bool loadConfig();

--- a/config.h
+++ b/config.h
@@ -15,5 +15,6 @@ extern bool useKeyboard;
 extern bool useBana;
 extern bool useLimiter;
 extern char* redirectBanaReader;
+extern bool termSpoof;
 
 bool loadConfig();

--- a/library.cpp
+++ b/library.cpp
@@ -393,9 +393,9 @@ defineHook(int, connect, int sockfd, const struct sockaddr *addr, socklen_t addr
 
     printf("connect %s %d\n", ip, port);
 
-    /*if (port == 50765) {
+    if (port == 50765 && termSpoof) {
         in->sin_addr.s_addr = inet_addr("127.0.0.1");
-    }*/
+    }
 
     return callOld(connect, sockfd, addr, addrlen);
 }
@@ -480,7 +480,8 @@ defineHook(ssize_t, recvmsg, int fd, struct msghdr *msg, int flags) {
                             break;
                         }
                         case 4: {
-                            //in->sin_addr.s_addr = inet_addr("192.168.92.20");
+                            if (termSpoof)
+                                in->sin_addr.s_addr = inet_addr("192.168.92.20");
                             break;
                         }
                     }

--- a/library.cpp
+++ b/library.cpp
@@ -81,6 +81,15 @@ defineHook(int, open, const char *pathname, int flags, ...) {
         return ret;
     }
 
+    if (strcmp(pathname, "/dev/ttyS3") == 0 && redirectBanaReader){
+        printf("open banareader %s\n", redirectBanaReader);
+        int ret = callOld(open, redirectBanaReader, flags);
+        if (ret == -1) {
+            printf("cant open banareader %d\n", errno);
+        }
+        return ret;
+    }
+
     if ((strcmp(pathname, "/dev/ttyS2") == 0 || strcmp(pathname, "/dev/tnt0") == 0) && useJvs)
         return jvsFd;
 
@@ -568,6 +577,9 @@ void initialize_wlldr() {
 
     if (redirectMagneticCard)
         printf("Redirecting mgcard to %s\n", redirectMagneticCard);
+
+    if (redirectBanaReader)
+        printf("Redirecting banareader to %s\n", redirectBanaReader);
 
     initHasp();
     printf("hasp\n");

--- a/library.cpp
+++ b/library.cpp
@@ -575,6 +575,11 @@ void initialize_wlldr() {
 
     printf("terminal=%d, mt4=%d\n", isTerminal, isMt4);
 
+    if (redirectBanaReader && useBana) {
+        printf("Unable to enable Banapass Emulation and Banapass Reader Redirect, please check config and try again.");
+        exit(1);
+    }
+
     if (redirectMagneticCard)
         printf("Redirecting mgcard to %s\n", redirectMagneticCard);
 

--- a/library.cpp
+++ b/library.cpp
@@ -393,9 +393,9 @@ defineHook(int, connect, int sockfd, const struct sockaddr *addr, socklen_t addr
 
     printf("connect %s %d\n", ip, port);
 
-    if (port == 50765) {
+    /*if (port == 50765) {
         in->sin_addr.s_addr = inet_addr("127.0.0.1");
-    }
+    }*/
 
     return callOld(connect, sockfd, addr, addrlen);
 }
@@ -480,7 +480,7 @@ defineHook(ssize_t, recvmsg, int fd, struct msghdr *msg, int flags) {
                             break;
                         }
                         case 4: {
-                            in->sin_addr.s_addr = inet_addr("192.168.92.20");
+                            //in->sin_addr.s_addr = inet_addr("192.168.92.20");
                             break;
                         }
                     }


### PR DESCRIPTION
## Issue
When attempting to use a device like an [AIC-Pico](https://github.com/whowechina/aic_pico) under Linux, it shows up as an ACM device (for example `/dev/ttyACM0`) and therefore the game does not detect the new card reader, as it is hardcoded to detect the device at `/dev/ttyS3`.
